### PR TITLE
Expand on readme example to show protoc usage and explain schema naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
           cache: pipenv
       - run: pip install pipenv
       - run: pipenv install --dev --deploy

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 mcap = "*"
 protobuf = "*"
+typing_extensions = "*"
 
 [dev-packages]
 black = "*"
@@ -14,4 +15,4 @@ pytest = "*"
 pyright = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e421563325cc43653e8dfa59bc72efe629fabbebdd0f76b329d0b25ccd33d465"
+            "sha256": "92b86aa675a3b3e1978c340de6d28df2c51d462ce4e9d311e1a8d1c125e970eb"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -45,11 +45,11 @@
         },
         "mcap": {
             "hashes": [
-                "sha256:28b8ed85faab1bea22fbfcf6e192c30895728c4f710c3a7396c9e370259cfb72",
-                "sha256:b192bb7091777ebfbe991c7faecaeedecf7407f2cd5d2eedfa8abb66481230bd"
+                "sha256:1c6eefbc4ab5bb2a6ad5734dece9e9a01b1580a7e98d799b2f896b23116fffb1",
+                "sha256:2b0e9746dd4d4b5714875f89072c4bef70905bab2e9bf2a1dfc6bdad2b46928c"
             ],
             "index": "pypi",
-            "version": "==0.0.6"
+            "version": "==0.0.7"
         },
         "protobuf": {
             "hashes": [
@@ -82,6 +82,14 @@
             ],
             "index": "pypi",
             "version": "==3.19.4"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+            ],
+            "index": "pypi",
+            "version": "==4.1.1"
         },
         "zstd": {
             "hashes": [
@@ -143,6 +151,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==8.0.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6",
+                "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.11.3"
         },
         "iniconfig": {
             "hashes": [
@@ -221,19 +237,19 @@
         },
         "pyright": {
             "hashes": [
-                "sha256:65997def7b096d13b4ec0049e407a3497f5eab3d86e94568793c761605eabed4",
-                "sha256:9b6de0d69d25d40a775d7562b199ba055e1c443dcad37615e4d1b818983dcad6"
+                "sha256:26ad23aef696b0e44bb1d4afb3d97dd278b51a4b72631b2040164273d46b4e39",
+                "sha256:6a9aaf49967ac5fe18235b4521de6d4a9ae44042b56a8409b627970e52d1522a"
             ],
             "index": "pypi",
-            "version": "==1.1.228"
+            "version": "==1.1.230"
         },
         "pytest": {
             "hashes": [
-                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
-                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
+                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
+                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==7.1.0"
         },
         "tomli": {
             "hashes": [
@@ -243,13 +259,51 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e",
+                "sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344",
+                "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266",
+                "sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a",
+                "sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd",
+                "sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d",
+                "sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837",
+                "sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098",
+                "sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e",
+                "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27",
+                "sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b",
+                "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596",
+                "sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76",
+                "sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30",
+                "sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4",
+                "sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78",
+                "sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca",
+                "sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985",
+                "sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb",
+                "sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88",
+                "sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7",
+                "sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5",
+                "sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e",
+                "sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7"
+            ],
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "version": "==1.5.2"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
                 "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
             ],
-            "markers": "python_version < '3.10'",
+            "index": "pypi",
             "version": "==4.1.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
+                "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.7.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ pipenv install mcap-protobuf-support
 
 ## MCAP protobuf writing example
 
+First, compile each of your message definitions:
+
+```bash
+protoc complex_message.proto --python_out . -o complex_message.fds
+protoc simple_message.proto --python_out . -o simple_message.fds
+```
+
+Next, use those message definitions to register schema in the mcap file. _Note_ that the names
+of the messages in the proto files must correspond to the schema names in the mcap file. For example,
+the message type `SimpleMessage` in the .proto file must be registered as an mcap schema with the name
+`SimpleMessage`.
+
 ```python
 from pathlib import Path
 from typing import IO, Any

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap-protobuf-support
-version = 0.0.2
+version = 0.0.3
 description = Protobuf support for the Python MCAP library
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     protobuf
 install_package_data = True
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.7
 
 [options.package_data]
 mcap_protobuf = py.typed

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -13,7 +13,7 @@ def test_protobuf_decoder():
     generate_sample_data(output)
     assert (
         hashlib.sha256(output.getvalue()).hexdigest()
-        == "674168d7005e806cc89401385b962fcaa650d34ed2927c4ae25dfc991cb9e321"
+        == "693af8e1f070bbd11a0bfc7e8c870f37b48672b133bc4af81d2ab5c5a5cc46bc"
     )
     reader = StreamReader(cast(RawIOBase, output))
     decoder = Decoder(reader)


### PR DESCRIPTION
**Public-Facing Changes**
This improves the sample code in the readme to clarify compiling file descriptor sets and schema naming.

It also lowers the python requirement to 3.7 for wider compatibility.

<!-- link relevant GitHub issues -->
