### PR TITLE
Register schema directly from the generated python message classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,20 @@ pipenv install mcap-protobuf-support
 
 ## MCAP protobuf writing example
 
-First, compile each of your message definitions:
+First, compile all of your message definitions:
 
 ```bash
-protoc complex_message.proto --python_out . -o complex_message.fds
-protoc simple_message.proto --python_out . -o simple_message.fds
+protoc *.proto --python_out .
 ```
 
-Next, use those message definitions to register schema in the mcap file. _Note_ that the names
-of the messages in the proto files must correspond to the schema names in the mcap file. For example,
-the message type `SimpleMessage` in the .proto file must be registered as an mcap schema with the name
-`SimpleMessage`.
+Next, use the classes generated from those message definitions to register schema in the mcap file.
 
 ```python
 from pathlib import Path
 from typing import IO, Any
 
 from mcap.mcap0.writer import Writer as McapWriter
+from mcap_protobuf.schema import register_schema
 
 from .complex_message_pb2 import ComplexMessage
 from .simple_message_pb2 import SimpleMessage
@@ -37,16 +34,10 @@ output = open("example.mcap", "wb")
 mcap_writer = McapWriter(output)
 mcap_writer.start(profile="protobuf", library="test")
 
-simple_schema_id = mcap_writer.register_schema(
-    name="SimpleMessage",
-    encoding="protobuf",
-    data=(Path(__file__).parent / "simple_message.fds").read_bytes(),
-)
+simple_schema_id = register_schema(writer=mcap_writer, message_class=SimpleMessage)
 
-complex_schema_id = mcap_writer.register_schema(
-    name="ComplexMessage",
-    encoding="protobuf",
-    data=(Path(__file__).parent / "complex_message.fds").read_bytes(),
+complex_schema_id = register_schema(
+    writer=mcap_writer, message_class=ComplexMessage
 )
 
 simple_channel_id = mcap_writer.register_channel(

--- a/mcap_protobuf/schema.py
+++ b/mcap_protobuf/schema.py
@@ -1,0 +1,14 @@
+from typing import Any
+import google.protobuf.descriptor_pb2
+from mcap.mcap0.writer import Writer as McapWriter
+
+
+def register_schema(writer: McapWriter, message_class: Any):
+    fds = google.protobuf.descriptor_pb2.FileDescriptorSet()
+    fds.file.append(google.protobuf.descriptor_pb2.FileDescriptorProto())
+    fds.file[0].ParseFromString(message_class.DESCRIPTOR.file.serialized_pb)
+    data = fds.SerializeToString()
+
+    return writer.register_schema(
+        name=message_class.DESCRIPTOR.name, encoding="protobuf", data=data
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap-protobuf-support
-version = 0.0.3
+version = 0.0.4
 description = Protobuf support for the Python MCAP library
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/complex_message.fds
+++ b/tests/complex_message.fds
@@ -1,6 +1,0 @@
-
-a
-complex_message.proto"@
-ComplexMessage
-fieldA (	RfieldA
-fieldB (	RfieldBbproto3

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 from typing import IO, Any
 
 from mcap.mcap0.writer import Writer as McapWriter
+from mcap_protobuf.schema import register_schema
 
 from .complex_message_pb2 import ComplexMessage
 from .simple_message_pb2 import SimpleMessage
@@ -11,16 +11,10 @@ def generate_sample_data(output: IO[Any]):
     mcap_writer = McapWriter(output)
     mcap_writer.start(profile="protobuf", library="test")
 
-    simple_schema_id = mcap_writer.register_schema(
-        name="SimpleMessage",
-        encoding="protobuf",
-        data=(Path(__file__).parent / "simple_message.fds").read_bytes(),
-    )
+    simple_schema_id = register_schema(writer=mcap_writer, message_class=SimpleMessage)
 
-    complex_schema_id = mcap_writer.register_schema(
-        name="ComplexMessage",
-        encoding="protobuf",
-        data=(Path(__file__).parent / "complex_message.fds").read_bytes(),
+    complex_schema_id = register_schema(
+        writer=mcap_writer, message_class=ComplexMessage
     )
 
     simple_channel_id = mcap_writer.register_channel(

--- a/tests/simple_message.fds
+++ b/tests/simple_message.fds
@@ -1,5 +1,0 @@
-
-C
-simple_message.proto"#
-SimpleMessage
-data (	Rdatabproto3

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -13,7 +13,7 @@ def test_protobuf_decoder():
     generate_sample_data(output)
     assert (
         hashlib.sha256(output.getvalue()).hexdigest()
-        == "693af8e1f070bbd11a0bfc7e8c870f37b48672b133bc4af81d2ab5c5a5cc46bc"
+        == "98e4525e60b24435a3ee93b46f55f533a42b192db58d6bd1eca636d5b40078b8"
     )
     reader = StreamReader(cast(RawIOBase, output))
     decoder = Decoder(reader)


### PR DESCRIPTION
**Public-Facing Changes**
This allows users to register protobuf schema directly from the generated python classes instead of having to use the command line `protoc` compiler to generate intermediate file descriptor sets.
